### PR TITLE
Add support for generic file types

### DIFF
--- a/Examples.js
+++ b/Examples.js
@@ -6,7 +6,7 @@ function example_run_sync() {
   //let gdFolderSearchParams = "0Xxx_0XxxxX1XXX1xXXxxXXxxx0X";
   let gdFolderSearchParams = "title = 'Books' and mimeType = 'application/vnd.google-apps.folder'"
   
-  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, "Google Drive", "update", ["SkipFolder1", "SkipFolder2"]);
+  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, "Google Drive", "update", ["SkipFolder1", "SkipFolder2"], null, ["pdf", "epub"]);
   sync.run();
 }
 
@@ -29,7 +29,7 @@ function example_force_sync() {
 //  const forceFunc = (r, s) => r["VissibleName"] == "needs_force_push.pdf";
 //  const forceFunc = (r, s) => s["Version"] == 1;
   
-  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, "Google Drive", "update", [], forceFunc);
+  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, "Google Drive", "update", [], forceFunc, ["pdf", "epub"]);
   sync.run();
 }
 

--- a/Library.js
+++ b/Library.js
@@ -6,9 +6,10 @@
  * @rRootFolder {string} root folder on Remarkable to sync files to - must already exist. This can be a Remarkable GUID if you know it.
  * @syncMode {string} either "update" or "mirror". Mirroring removes files on device if they no longer exist in Google Drive.
  * @gdSkipFolders {array} list of names of Google Drive folders to skip syncing.
+ * @formats (array) list of file type formats to upload, defaults to just pdf. epub has also been tested
  */
-function syncGoogleDriveWithRemarkableCloud(rOneTimeCode, gdFolderSearchParams, rRootFolder, syncMode="update", gdSkipFolders=[]) {
-  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, rRootFolder, syncMode, gdSkipFolders);
+function syncGoogleDriveWithRemarkableCloud(rOneTimeCode, gdFolderSearchParams, rRootFolder, syncMode="update", gdSkipFolders=[], formats=["pdf"]) {
+  let sync = new Synchronizer(rOneTimeCode, gdFolderSearchParams, rRootFolder, syncMode, gdSkipFolders, formats);
   sync.run();
 }
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Click in menu "Resources/Libraries" and in "Add a library" paste "1_ftsHelqnCqBX
           let rOneTimeCode = "abcdwxyz";
           let gdFolderSearchParams = "title = 'Books' and mimeType = 'application/vnd.google-apps.folder'";
           let syncMode = "mirror";
-          RemarkableGoogleDriveSyncLib.syncGoogleDriveWithRemarkableCloud(rOneTimeCode, gdFolderSearchParams, "Google Drive", syncMode);
+		  const skipFolders = [];
+		  const formats = ["pdf, "epub"];
+          RemarkableGoogleDriveSyncLib.syncGoogleDriveWithRemarkableCloud(rOneTimeCode, gdFolderSearchParams, "Google Drive", syncMode, skipFolders, formats);
         }
 
     Change the rOneTimeCode to include a one time code obtained from https://my.remarkable.com/connect/mobile. Also change the name "Books" in gdFolderSearchParams to the name of your Google Drive folder that contains your relevant PDFs. You can also replace the gdFolderSearchParams with a Google Drive folder ID. syncMode can be either "update" or "mirror" with
@@ -42,4 +44,4 @@ That should be it!
 
 * This is a one way sync from Google Drive to Remarkable.
 * Files greater than 50MB in size are not transferred. This appears to be a limit set by reMarkable.
-* Currently, only PDF files are transferred. Adding support for EPUB and other types isn't difficult and might be added later. 
+* Currently, only PDF and EPub files formats have been tested. Other should work as long as reMarkable's Api accepts them


### PR DESCRIPTION
I wanted to have sync epub files and it was just easier to add support for any generic file type rather than hardcode in just epub and pdf. I updated the README how I thought it should look, but it's your project so feel free to change that to whatever you want. I also modified the Examples, but didn't really have a way to test them, so I figured you would do that. I am fairly certain they will work. 