### PR TITLE
Resolves #9 - google document and spreadsheet sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Thanks to splitbrain who did the [initial reverse engineering of Remarkable's cl
 Click in menu "File/Rename" and provide suitable name, eg "Sync Google Drive Books to Remarkable".
 
     1. Option 1 - Include library from Apps Script
-Click in menu "Resources/Libraries" and in "Add a library" paste "1_ftsHelqnCqBXAwFAOv3U-WUUm_n3_nENg7n6BrDDzze7EekBD9vmf-0" without the double quotes. In version drop down choose "Stable - include epub and shortcuts" Then press "Save" button.
+Click in menu "Resources/Libraries" and in "Add a library" paste "1_ftsHelqnCqBXAwFAOv3U-WUUm_n3_nENg7n6BrDDzze7EekBD9vmf-0" without the double quotes. In version drop down choose "Stable" or version "14" Then press "Save" button.
 
     2. Option 2 - Copy the code files from this repository into your Apps Script project being careful to rename the *.js files to *.gs files.
 
@@ -37,6 +37,17 @@ Click in menu "Resources/Libraries" and in "Add a library" paste "1_ftsHelqnCqBX
 6. Set up a regular trigger by click in menu "Edit/Current project's triggers". Click "+ Add Trigger" button. Choose run_sync function and select "Time-driver", "Hour timer", "Every hour" and "Notify me daily" then press Save.
 
 That should be it!
+    
+# Troubleshooting
+
+1. If you need to reset your authentication credentials, in your Code.gs paste the following code:
+
+        function reset() {
+         RemarkableGoogleDriveSyncLib.resetRemarkableDevice(); 
+        }
+    
+    Run the above reset function and update the rOneTimeCode with a new obtained from Remarkable's devices page.
+    
 
 # Limitations
 

--- a/Remarkable.js
+++ b/Remarkable.js
@@ -1,7 +1,9 @@
+AUTH_HOST = "https://webapp-production-dot-remarkable-production.appspot.com";
+
 class RemarkableAPI {
 
   constructor(deviceId = null, deviceToken = null, oneTimeCode = null) {
-    // oneTimeCode from https://my.remarkable.com/connect/mobile
+    // oneTimeCode from ${AUTH_HOST}/connect/mobile
     if (deviceToken === null && oneTimeCode === null) {
       throw "Need at least either device-token or one-time-code";
     }
@@ -28,6 +30,7 @@ class RemarkableAPI {
     this.storageHost = this.constructor._getStorageHost(this.userToken);
   }
 
+
   // https://github.com/splitbrain/ReMarkableAPI/wiki/Authentication
 
   static _getDeviceToken(deviceId, oneTimeCode) {
@@ -42,7 +45,7 @@ class RemarkableAPI {
       'payload': JSON.stringify(data)
     };
     // https://developers.google.com/apps-script/reference/url-fetch/url-fetch-app
-    let response = UrlFetchApp.fetch('https://my.remarkable.com/token/json/2/device/new', options);
+    let response = UrlFetchApp.fetch(`${AUTH_HOST}/token/json/2/device/new`, options);
     let deviceToken = response.getContentText()
     //Logger.log(`Received device token: ${deviceToken}`);
     return deviceToken;
@@ -57,7 +60,7 @@ class RemarkableAPI {
         'Authorization': `Bearer ${deviceToken}`
       }
     };
-    let response = UrlFetchApp.fetch('https://my.remarkable.com/token/json/2/user/new', options);
+    let response = UrlFetchApp.fetch(`${AUTH_HOST}/token/json/2/user/new`, options);
     let userToken = response.getContentText()
     //Logger.log(`Received user Token: ${userToken}`);
     return userToken;


### PR DESCRIPTION
* Adding a lastRunTime variable
* Adding `ModifiedClient` and `_gdMimeType` to the document object (Not sure how to update the API with the new `ModifiedClient` on server)
* Modified the script to search based on MimeType rather than file extension. Made it extensible to add MimeTypes in the future
* Limiting GDrive files to Spreadsheets and Documents

Gotcha:
* Google Drive items do not count towards a storage quota and therefore are counted as 0 bytes. I am unsure how to prevent large files from being uploaded.