### PR TITLE
Don't reupload files already on device.

### DIFF
--- a/Remarkable.js
+++ b/Remarkable.js
@@ -1,3 +1,9 @@
+function stripExtension(fname) {
+  let last = fname.lastIndexOf('.');
+  if (last === -1) return fname;
+  return fname.substr(0, last);
+}
+
 class RemarkableAPI {
 
   constructor(deviceId = null, deviceToken = null, oneTimeCode = null) {
@@ -181,8 +187,8 @@ class RemarkableAPI {
   
   downloadBlob(doc) {
     let blob = this._downloadBlob(doc["BlobURLGet"]);
-    let name = doc["VissibleName"].replace('.pdf', '.bin');
-    blob.setName(name);
+    let name = stripExtension(doc["VissibleName"]);
+    blob.setName(`${name}.bin`);
     return blob;
   }
   

--- a/Remarkable.js
+++ b/Remarkable.js
@@ -178,6 +178,23 @@ class RemarkableAPI {
     let res = JSON.parse(text);
     return res;
   }
+  
+  downloadBlob(doc) {
+    let blob = this._downloadBlob(doc["BlobURLGet"]);
+    let name = doc["VissibleName"].replace('.pdf', '.bin');
+    blob.setName(name);
+    return blob;
+  }
+  
+  _downloadBlob(url) {
+    let response = UrlFetchApp.fetch(url, {
+      'method': 'GET',
+      'headers': {
+        'Authorization': `Bearer ${this.userToken}`
+      },
+    });
+    return response.getBlob();
+  }
 
   delete(data) {
     let payloadData = data.map((r) => (

--- a/Synchronizer.js
+++ b/Synchronizer.js
@@ -317,7 +317,7 @@ class Synchronizer {
           // upload files if not already on device.
           // if forced, upload regardless of whether they're on device.
           let alreadyOnDevice = rDescIds.has(doc["ID"]);
-          if (doc["Success"] && (this._forcedUpdate(uploadDocChunk) || !alreadyOnDevice)) {
+          if (doc["Success"] && (this._forcedUpdate(doc) || !alreadyOnDevice)) {
             try {
               let gdFileId = this.UUIDToGdId[doc["ID"]];
               let gdFileObj = DriveApp.getFileById(gdFileId);


### PR DESCRIPTION
I annotate books on my ReMarkable, but given the current code moving their location would reupload PDFs and overwrite the annotations during next sync.

This PR alleviates the problem by only reuploading if explicitly forced to do so (note, I haven't tested usage of `forceUpdateFunc` since this is functionality I don't need).